### PR TITLE
LIBMOBILE-1276 - Bump up analytics-kotlin version to latest. 

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,13 +9,13 @@ plugins {
 val VERSION_NAME: String by project
 
 android {
-    compileSdk = 31
-    buildToolsVersion = "31.0.0"
+    compileSdk = 33
+    buildToolsVersion = "33.0.1"
 
     defaultConfig {
         multiDexEnabled = true
         minSdk = 16
-        targetSdk = 31
+        targetSdk = 33
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("proguard-consumer-rules.pro")
@@ -40,15 +40,15 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.2")
 
-    implementation("com.segment.analytics.kotlin:android:1.5.0")
+    implementation("com.segment.analytics.kotlin:android:1.10.3")
     implementation("androidx.multidex:multidex:2.0.1")
 
-    implementation("androidx.core:core-ktx:1.7.0")
-    implementation("androidx.appcompat:appcompat:1.4.1")
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.5.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.3")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     implementation("androidx.lifecycle:lifecycle-process:2.4.1")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.4.1")
@@ -56,23 +56,23 @@ dependencies {
 
 // Partner Dependencies
 dependencies {
-    implementation("com.mixpanel.android:mixpanel-android:5.8.7")
+    implementation("com.mixpanel.android:mixpanel-android:7.3.0")
 }
 
 // Test Dependencies
 dependencies {
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
 
-    testImplementation("io.mockk:mockk:1.12.2")
+    testImplementation("io.mockk:mockk:1.12.4")
     testImplementation(platform("org.junit:junit-bom:5.7.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 
     // Add Roboelectric dependencies.
     testImplementation("org.robolectric:robolectric:4.7.3")
-    testImplementation("androidx.test:core:1.4.0")
+    testImplementation("androidx.test:core:1.5.0")
 
     // Add JUnit4 legacy dependencies.
     testImplementation("junit:junit:4.13.2")

--- a/lib/src/test/java/com/segment/analytics/kotlin/destinations/mixpanel/MixpanelDestinationTests.kt
+++ b/lib/src/test/java/com/segment/analytics/kotlin/destinations/mixpanel/MixpanelDestinationTests.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import com.segment.analytics.kotlin.core.*
 import com.segment.analytics.kotlin.core.platform.Plugin
-import com.segment.analytics.kotlin.destinations.mixpanel.MixpanelDestination
-import com.segment.analytics.kotlin.destinations.mixpanel.MixpanelSettings
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.serialization.decodeFromString
@@ -33,7 +31,7 @@ class MixpanelDestinationTests {
     init {
         MockKAnnotations.init(this)
         mockkStatic(MixpanelAPI::class)
-        every { MixpanelAPI.getInstance(mockContext, any()) } returns mockMixpanel
+        every { MixpanelAPI.getInstance(mockContext, any(), any()) } returns mockMixpanel
         every { mockMixpanel.people } returns mockMixpanelPeople
         every { mockMixpanel.getGroup(any(), any()) } returns mockMixpanelGroup
 
@@ -420,7 +418,7 @@ class MixpanelDestinationTests {
         }
 
         verify {
-            mockMixpanelPeople.set("Last Product Clicked", any());
+            mockMixpanelPeople.set("Last Product Clicked", any())
         }
     }
 


### PR DESCRIPTION
LIBMOBILE-1276 
- upgraded Analytics version from 1.5.0 to 1.10.3
- upgraded Mixpanel version from 5.8.7 to 7.3.0
- upgraded target and compile SDK version from 31 to 33
- upgraded ktx:core, test:core, mockk, test:junit, appcompat, espresso to latest
- added "trackAutomaticEvents" variable in MixpanelSettings
- due to the changes in Mixpanel SDK -> sending "trackAutomaticEvents" MixpanelAPI.getInstance() in MixpanelDestination
- added parameter in every block for test case in MixpanelDestinationTests