### PR TITLE
Support EU API URL and bump Mixpanel to 7.3.3 from 7.3.0

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
 
 // Partner Dependencies
 dependencies {
-    implementation("com.mixpanel.android:mixpanel-android:7.3.0")
+    implementation("com.mixpanel.android:mixpanel-android:7.3.3")
 }
 
 // Test Dependencies

--- a/lib/src/test/java/com/segment/analytics/kotlin/destinations/mixpanel/MixpanelDestinationTests.kt
+++ b/lib/src/test/java/com/segment/analytics/kotlin/destinations/mixpanel/MixpanelDestinationTests.kt
@@ -80,8 +80,8 @@ class MixpanelDestinationTests {
         mixpanelDestination.update(settingsBlob, Plugin.UpdateType.Initial)
 
         /* assertions about config */
-        Assertions.assertNotNull(mixpanelDestination.settings)
-        with(mixpanelDestination.settings!!) {
+        Assertions.assertNotNull(mixpanelDestination.mixpanelSettings)
+        with(mixpanelDestination.mixpanelSettings!!) {
             Assertions.assertFalse(consolidatedPageCalls)
             Assertions.assertTrue(isPeopleEnabled)
             Assertions.assertFalse(trackAllPages)
@@ -854,7 +854,7 @@ class MixpanelDestinationTests {
 
     private fun MixpanelDestination.setupTest(mixpanelSettings: MixpanelSettings) {
         this.mixpanel = mockMixpanel
-        this.settings = mixpanelSettings
+        this.mixpanelSettings = mixpanelSettings
     }
 
     data class JsonObjectMatcher(


### PR DESCRIPTION
Adding support for a new configuration flag (enableEuropeanUnionEndpoint; default is false) that will allow us to set the Mixpanel API URL to it's EU API URL: "https://api-eu.mixpanel.com"