### PR TITLE
feat: Integrated sessionreplay plugin

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         multiDexEnabled = true
-        minSdk = 16
+        minSdk = 21
         targetSdk = 33
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
@@ -56,7 +56,8 @@ dependencies {
 
 // Partner Dependencies
 dependencies {
-    implementation("com.mixpanel.android:mixpanel-android:7.3.3")
+    implementation("com.mixpanel.android:mixpanel-android:8.8.0")
+    implementation("com.mixpanel.android:mixpanel-android-session-replay:1.4.0")
 }
 
 // Test Dependencies

--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/mixpanel/MixpanelDestination.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/mixpanel/MixpanelDestination.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import android.content.Context
 import android.os.Bundle
 import com.mixpanel.android.mpmetrics.MixpanelAPI
+import com.mixpanel.android.sessionreplay.MPSessionReplay
+import com.mixpanel.android.sessionreplay.models.MPSessionReplayConfig
+import com.mixpanel.android.sessionreplay.utils.DataResidency
 import com.segment.analytics.kotlin.android.plugins.AndroidLifecycle
 import com.segment.analytics.kotlin.android.utilities.toJSONObject
 import com.segment.analytics.kotlin.core.*
@@ -69,7 +72,9 @@ data class MixpanelSettings(
 )
 
 class MixpanelDestination(
-    private val context: Context
+    private val context: Context,
+    private val sessionReplayEnabled: Boolean = false,
+    private val sessionReplayConfig: MPSessionReplayConfig = MPSessionReplayConfig()
 ) : DestinationPlugin(), AndroidLifecycle, VersionedPlugin {
 
     internal var mixpanelSettings: MixpanelSettings? = null
@@ -91,6 +96,22 @@ class MixpanelDestination(
 
                 if (mixpanelSettings?.enableEuropeanUnionEndpoint == true) {
                     mixpanel?.setServerURL("https://api-eu.mixpanel.com")
+                }
+
+                if (sessionReplayEnabled) {
+                    val euEnabled = mixpanelSettings?.enableEuropeanUnionEndpoint == true
+                    val configWithResidency = if (euEnabled) {
+                        sessionReplayConfig.copy(serverUrl = DataResidency.EU)
+                    } else {
+                        sessionReplayConfig
+                    }
+                    MPSessionReplay.initialize(
+                        appContext = context,
+                        token = this.mixpanelSettings?.token ?: "",
+                        distinctId = mixpanel?.distinctId ?: "",
+                        config = configWithResidency
+                    )
+                    analytics.log("Mixpanel Session Replay initialized")
                 }
 
                 analytics.log("Mixpanel Destination loaded")
@@ -126,6 +147,9 @@ class MixpanelDestination(
         if (userId.isNotEmpty()) {
             mixpanel?.identify(userId)
             analytics.log("mixpanel.identify($userId)")
+            if (sessionReplayEnabled) {
+                MPSessionReplay.getInstance()?.identify(userId)
+            }
         }
 
         with(settings) {


### PR DESCRIPTION
**Here's a summary of all changes made:**
**1. [lib/build.gradle.kts](vscode-webview://1o35bhtj49h0c0qlimlrbd48bnhrdhd6pkvlpfn2uci9sj55iia9/lib/build.gradle.kts)**
minSdk raised from 16 → 21 (session replay SDK requirement)
mixpanel-android bumped from 7.3.3 → 8.8.0 (minimum required for session replay)
Added com.mixpanel.android:mixpanel-android-session-replay:1.4.0



**2. [MixpanelDestination.kt](vscode-webview://1o35bhtj49h0c0qlimlrbd48bnhrdhd6pkvlpfn2uci9sj55iia9/lib/src/main/java/com/segment/analytics/kotlin/destinations/mixpanel/MixpanelDestination.kt)**

New imports: MPSessionReplay, MPSessionReplayConfig, DataResidency
New constructor params:

class MixpanelDestination(
    private val context: Context,
    private val sessionReplayEnabled: Boolean = false,          // opt-in
    private val sessionReplayConfig: MPSessionReplayConfig = MPSessionReplayConfig()  // customise behaviour
)
update() — when sessionReplayEnabled = true, calls MPSessionReplay.initialize() after MixpanelAPI is ready. Automatically sets serverUrl = DataResidency.EU if the EU endpoint flag is on in the Segment dashboard.
identify() — calls MPSessionReplay.getInstance()?.identify(userId) to keep the replay distinct ID in sync when a user logs in.

**Usage**
**Minimal** — replay on with defaults (100% sampling, wifi-only flush):

analytics.add(plugin = MixpanelDestination(
    context = applicationContext,
    sessionReplayEnabled = true
))

**Custom config:**
analytics.add(plugin = MixpanelDestination(
    context = applicationContext,
    sessionReplayEnabled = true,
    sessionReplayConfig = MPSessionReplayConfig(
        recordingSessionsPercent = 50.0,  // record 50% of sessions
        wifiOnly = false,                  // flush on any network
        enableLogging = true               // debug logs
    )
))

**Replay off** (default — no behaviour change from before):
analytics.add(plugin = MixpanelDestination(context = applicationContext))